### PR TITLE
Refactor diff viewer into dual inline editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/diff": "^5.2.3",
+        "@types/prismjs": "^1.26.5",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1395,9 +1397,10 @@
       }
     },
     "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
+      "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1418,6 +1421,7 @@
       "version": "1.26.5",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
       "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {

--- a/src/components/DiffViewer/DiffViewer.css
+++ b/src/components/DiffViewer/DiffViewer.css
@@ -1,23 +1,21 @@
-/* VS Code Dark Theme Colors */
 :root {
   --vscode-bg: #1e1e1e;
   --vscode-sidebar-bg: #252526;
   --vscode-editor-bg: #1e1e1e;
   --vscode-line-number: #858585;
   --vscode-text: #d4d4d4;
-  --vscode-added-bg: rgba(155, 185, 85, 0.2);
+  --vscode-added-bg: rgba(155, 185, 85, 0.25);
   --vscode-added-border: #9bb955;
-  --vscode-removed-bg: rgba(255, 97, 136, 0.2);
+  --vscode-removed-bg: rgba(255, 97, 136, 0.28);
   --vscode-removed-border: #ff6188;
-  --vscode-modified-bg: rgba(255, 197, 61, 0.2);
+  --vscode-modified-bg: rgba(255, 197, 61, 0.28);
   --vscode-modified-border: #ffc53d;
   --vscode-header-bg: #2d2d30;
-  --vscode-border: #464647;
+  --vscode-border: #3c3c41;
   --vscode-hover: #2a2d2e;
   --vscode-button-bg: #0e639c;
   --vscode-button-hover: #1177bb;
-  --vscode-input-bg: #3c3c3c;
-  --vscode-input-border: #464647;
+  --vscode-placeholder: #6e6e6e;
 }
 
 .diff-viewer-container {
@@ -34,7 +32,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 20px;
+  padding: 12px 20px;
   background-color: var(--vscode-header-bg);
   border-bottom: 1px solid var(--vscode-border);
 }
@@ -42,9 +40,9 @@
 .diff-viewer-title {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 14px;
+  gap: 10px;
   font-weight: 600;
+  letter-spacing: 0.2px;
 }
 
 .diff-viewer-title .icon {
@@ -59,118 +57,98 @@
   gap: 16px;
 }
 
-.diff-stats {
-  display: flex;
-  gap: 8px;
-  font-size: 12px;
-}
-
-.stat {
-  padding: 2px 8px;
-  border-radius: 3px;
-  font-weight: 600;
-}
-
-.stat.additions {
-  background-color: rgba(155, 185, 85, 0.3);
-  color: #9bb955;
-}
-
-.stat.deletions {
-  background-color: rgba(255, 97, 136, 0.3);
-  color: #ff6188;
-}
-
 .language-selector {
   padding: 4px 8px;
-  background-color: var(--vscode-input-bg);
+  background-color: var(--vscode-sidebar-bg);
   color: var(--vscode-text);
-  border: 1px solid var(--vscode-input-border);
-  border-radius: 3px;
+  border: 1px solid var(--vscode-border);
+  border-radius: 4px;
   font-size: 12px;
   cursor: pointer;
-  outline: none;
 }
 
 .language-selector:hover {
   background-color: var(--vscode-hover);
 }
 
-.view-mode-toggle {
+.diff-stats {
   display: flex;
-  background-color: var(--vscode-input-bg);
-  border: 1px solid var(--vscode-input-border);
-  border-radius: 3px;
-  overflow: hidden;
+  gap: 10px;
+  font-size: 12px;
 }
 
-.view-mode-btn {
-  display: flex;
+.stat {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 26px;
-  background: transparent;
-  border: none;
-  color: var(--vscode-text);
-  cursor: pointer;
-  transition: background-color 0.2s;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-weight: 600;
+  border: 1px solid transparent;
 }
 
-.view-mode-btn svg {
-  width: 16px;
-  height: 16px;
+.stat.additions {
+  color: var(--vscode-added-border);
+  background: var(--vscode-added-bg);
+  border-color: rgba(155, 185, 85, 0.4);
 }
 
-.view-mode-btn:hover {
-  background-color: var(--vscode-hover);
+.stat.deletions {
+  color: var(--vscode-removed-border);
+  background: var(--vscode-removed-bg);
+  border-color: rgba(255, 97, 136, 0.4);
 }
 
-.view-mode-btn.active {
-  background-color: var(--vscode-button-bg);
+.stat.modifications {
+  color: var(--vscode-modified-border);
+  background: var(--vscode-modified-bg);
+  border-color: rgba(255, 197, 61, 0.45);
 }
 
-.diff-viewer-input {
+.diff-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1px;
-  background-color: var(--vscode-border);
-  border-bottom: 1px solid var(--vscode-border);
-  min-height: 200px;
-  max-height: 300px;
+  flex: 1;
+  min-height: 0;
+  border-top: 1px solid var(--vscode-border);
 }
 
-.input-pane {
+.diff-pane {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   background-color: var(--vscode-editor-bg);
+  border-right: 1px solid var(--vscode-border);
+}
+
+.diff-pane:last-child {
+  border-right: none;
 }
 
 .pane-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
+  padding: 10px 16px;
   background-color: var(--vscode-sidebar-bg);
   border-bottom: 1px solid var(--vscode-border);
 }
 
 .pane-title {
-  font-size: 12px;
-  font-weight: 600;
   text-transform: uppercase;
-  color: #cccccc;
+  font-size: 12px;
+  color: #c5c5c5;
+  letter-spacing: 0.5px;
 }
 
 .clear-btn {
-  padding: 2px 8px;
-  background-color: transparent;
+  padding: 4px 10px;
+  font-size: 11px;
+  background: transparent;
   color: var(--vscode-text);
   border: 1px solid var(--vscode-border);
   border-radius: 3px;
-  font-size: 11px;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 .clear-btn:hover {
@@ -178,159 +156,131 @@
   border-color: var(--vscode-button-bg);
 }
 
-.code-input {
+.pane-editor {
+  position: relative;
   flex: 1;
-  padding: 12px;
-  background-color: var(--vscode-editor-bg);
-  color: var(--vscode-text);
-  border: none;
-  font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
-  font-size: 13px;
-  line-height: 1.5;
-  resize: none;
-  outline: none;
-}
-
-.code-input::placeholder {
-  color: #6e6e6e;
-  font-style: italic;
-}
-
-.diff-viewer-output {
-  flex: 1;
-  overflow: auto;
-  background-color: var(--vscode-editor-bg);
-}
-
-.diff-split-view {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1px;
-  height: 100%;
-  background-color: var(--vscode-border);
-}
-
-.diff-unified-view {
-  height: 100%;
-}
-
-.diff-pane {
-  display: flex;
-  flex-direction: column;
-  background-color: var(--vscode-editor-bg);
   overflow: hidden;
 }
 
-.diff-pane-header {
-  padding: 8px 12px;
-  background-color: var(--vscode-sidebar-bg);
-  border-bottom: 1px solid var(--vscode-border);
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: #cccccc;
+.code-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  background-color: var(--vscode-editor-bg);
 }
 
-.diff-content {
-  flex: 1;
-  overflow: auto;
+.code-layer-scroll {
+  position: absolute;
+  top: 0;
+  left: 0;
+  min-width: 100%;
+  padding: 16px;
+  font-family: inherit;
   font-size: 13px;
   line-height: 20px;
-}
-
-.diff-line {
-  display: flex;
-  min-height: 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-}
-
-.diff-line-added {
-  background-color: var(--vscode-added-bg);
-}
-
-.diff-line-removed {
-  background-color: var(--vscode-removed-bg);
-}
-
-.diff-line-empty {
-  background-color: var(--vscode-sidebar-bg);
-  opacity: 0.5;
-}
-
-.line-number {
-  display: inline-block;
-  min-width: 50px;
-  padding: 0 8px;
-  color: var(--vscode-line-number);
-  text-align: right;
-  background-color: rgba(0, 0, 0, 0.2);
-  user-select: none;
-  border-right: 1px solid var(--vscode-border);
-}
-
-.diff-marker {
-  display: inline-block;
-  width: 20px;
-  text-align: center;
   color: var(--vscode-text);
-  font-weight: bold;
+  white-space: pre;
+}
+
+.code-line {
+  display: flex;
+  gap: 12px;
+  min-height: 20px;
+  padding: 0 12px;
+  margin: 0 -12px;
+  border-left: 3px solid transparent;
+}
+
+.code-line-number {
+  display: inline-flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 36px;
+  color: var(--vscode-line-number);
   user-select: none;
 }
 
-.line-content {
-  flex: 1;
-  margin: 0;
-  padding: 0 12px;
+.code-line-content {
+  display: inline-block;
+  min-width: 0;
   white-space: pre;
-  overflow-x: auto;
 }
 
-.line-content code {
+.code-line code,
+.code-line-content code {
   font-family: inherit;
   background: transparent;
 }
 
-/* Scrollbar styling */
-.diff-content::-webkit-scrollbar,
+.code-line--added {
+  background: var(--vscode-added-bg);
+  border-left-color: var(--vscode-added-border);
+}
+
+.code-line--removed {
+  background: var(--vscode-removed-bg);
+  border-left-color: var(--vscode-removed-border);
+}
+
+.code-line--modified {
+  background: var(--vscode-modified-bg);
+  border-left-color: var(--vscode-modified-border);
+  box-shadow: inset 0 -1px 0 rgba(255, 197, 61, 0.3);
+}
+
+.code-line--empty {
+  color: var(--vscode-placeholder);
+}
+
+.code-input {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  padding: 16px;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 20px;
+  color: transparent;
+  caret-color: var(--vscode-text);
+  text-shadow: 0 0 0 var(--vscode-text);
+  border: none;
+  resize: none;
+  background: transparent;
+  outline: none;
+  overflow: auto;
+}
+
+.code-input::placeholder {
+  color: transparent;
+  text-shadow: 0 0 0 var(--vscode-placeholder);
+}
+
 .code-input::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
 
-.diff-content::-webkit-scrollbar-track,
 .code-input::-webkit-scrollbar-track {
   background: var(--vscode-editor-bg);
 }
 
-.diff-content::-webkit-scrollbar-thumb,
 .code-input::-webkit-scrollbar-thumb {
-  background: #424242;
-  border-radius: 5px;
+  background: #3e3e42;
+  border-radius: 6px;
 }
 
-.diff-content::-webkit-scrollbar-thumb:hover,
 .code-input::-webkit-scrollbar-thumb:hover {
-  background: #4e4e4e;
+  background: #4e4e52;
 }
 
-/* Responsive design */
-@media (max-width: 768px) {
-  .diff-viewer-input {
-    grid-template-columns: 1fr;
-    max-height: 400px;
-  }
-  
-  .diff-split-view {
+@media (max-width: 1024px) {
+  .diff-columns {
     grid-template-columns: 1fr;
   }
-  
-  .diff-viewer-controls {
-    flex-direction: column;
-    gap: 8px;
-  }
-  
-  .line-number {
-    min-width: 40px;
-    font-size: 11px;
+
+  .diff-pane + .diff-pane {
+    border-top: 1px solid var(--vscode-border);
   }
 }

--- a/src/components/DiffViewer/DiffViewer.tsx
+++ b/src/components/DiffViewer/DiffViewer.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { ClipboardEvent, UIEvent } from 'react';
 import * as Diff from 'diff';
 import Prism from 'prismjs';
 import '../../styles/prism-vsc-dark-plus.css';
@@ -9,279 +10,330 @@ import 'prismjs/components/prism-tsx';
 import 'prismjs/components/prism-css';
 import 'prismjs/components/prism-json';
 import './DiffViewer.css';
-import { type DiffLine, type DiffViewMode } from './types';
+import type { DiffComputation, DiffStats, PaneDiffLine } from './types';
 import clsx from 'clsx';
 
+type LanguageOption = {
+  value: string;
+  label: string;
+};
+
+interface DiffEditorPaneProps {
+  title: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onPaste: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
+  onClear: () => void;
+  lines: PaneDiffLine[];
+  highlightSyntax: (code: string) => string;
+}
+
+const LANGUAGE_OPTIONS: LanguageOption[] = [
+  { value: 'javascript', label: 'JavaScript' },
+  { value: 'typescript', label: 'TypeScript' },
+  { value: 'jsx', label: 'JSX' },
+  { value: 'tsx', label: 'TSX' },
+  { value: 'css', label: 'CSS' },
+  { value: 'json', label: 'JSON' },
+  { value: 'plaintext', label: 'Plain Text' },
+];
+
 const DiffViewer: React.FC = () => {
-  const [leftText, setLeftText] = useState<string>('');
-  const [rightText, setRightText] = useState<string>('');
-  const [viewMode, setViewMode] = useState<DiffViewMode>('split');
+  const [originalCode, setOriginalCode] = useState<string>('');
+  const [modifiedCode, setModifiedCode] = useState<string>('');
   const [language, setLanguage] = useState<string>('javascript');
 
-  const diffLines = useMemo((): DiffLine[] => {
-    if (!leftText && !rightText) return [];
+  const diffComputation = useMemo<DiffComputation>(() => {
+    return computeDiff(originalCode, modifiedCode);
+  }, [originalCode, modifiedCode]);
 
-    const diff = Diff.diffLines(leftText, rightText);
-    const lines: DiffLine[] = [];
-    let leftLineNumber = 1;
-    let rightLineNumber = 1;
+  const highlightSyntax = useCallback(
+    (code: string): string => {
+      if (!code) {
+        return '&nbsp;';
+      }
 
-    diff.forEach((part) => {
-      const partLines = part.value.split('\n').filter((_, index, arr) => 
-        index < arr.length - 1 || part.value[part.value.length - 1] !== '\n'
-      );
+      try {
+        const grammar = Prism.languages[language] || Prism.languages.plaintext;
+        return Prism.highlight(code, grammar, language);
+      } catch {
+        return code;
+      }
+    },
+    [language]
+  );
 
-      partLines.forEach((line) => {
-        if (part.added) {
-          lines.push({
-            type: 'added',
-            leftContent: '',
-            rightContent: line,
-            leftLineNumber: null,
-            rightLineNumber: rightLineNumber++,
-          });
-        } else if (part.removed) {
-          lines.push({
-            type: 'removed',
-            leftContent: line,
-            rightContent: '',
-            leftLineNumber: leftLineNumber++,
-            rightLineNumber: null,
-          });
-        } else {
-          lines.push({
-            type: 'unchanged',
-            leftContent: line,
-            rightContent: line,
-            leftLineNumber: leftLineNumber++,
-            rightLineNumber: rightLineNumber++,
-          });
-        }
-      });
-    });
-
-    return lines;
-  }, [leftText, rightText]);
-
-  const highlightSyntax = (code: string): string => {
-    if (!code) return '';
-    try {
-      const grammar = Prism.languages[language] || Prism.languages.plaintext;
-      return Prism.highlight(code, grammar, language);
-    } catch {
-      return code;
-    }
-  };
-
-  const handlePaste = (setter: (value: string) => void) => (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-    e.preventDefault();
-    const text = e.clipboardData.getData('text');
-    setter(text);
-  };
-
-  const stats = useMemo(() => {
-    const additions = diffLines.filter(l => l.type === 'added').length;
-    const deletions = diffLines.filter(l => l.type === 'removed').length;
-    return { additions, deletions };
-  }, [diffLines]);
+  const handlePaste = useCallback(
+    (setter: (value: string) => void) =>
+      (event: ClipboardEvent<HTMLTextAreaElement>) => {
+        event.preventDefault();
+        const text = event.clipboardData.getData('text');
+        setter(text);
+      },
+    []
+  );
 
   return (
     <div className="diff-viewer-container">
       <div className="diff-viewer-header">
         <div className="diff-viewer-title">
-          <svg className="icon" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M13.5 2H10L9 1H4L3 2H2.5L2 2.5V6H3V3H6.5L7.5 2H8.5L9.5 3H13V12.5L13.5 13H10V14H13.5L14 13.5V2.5L13.5 2Z"/>
-            <path d="M5.56 8.56L7 7.12L5.56 5.69L4.85 6.4L5.44 7H0V8H5.44L4.85 8.6L5.56 8.56Z"/>
-            <path d="M9.41 12.41L8 11L9.41 9.59L10.12 10.3L9.53 10.89H12V5H11V9.89H9.53L10.12 9.3L9.41 9.34V12.41Z"/>
+          <svg className="icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M13.5 2H10L9 1H4L3 2H2.5L2 2.5V6H3V3H6.5L7.5 2H8.5L9.5 3H13V12.5L13.5 13H10V14H13.5L14 13.5V2.5L13.5 2Z" />
+            <path d="M5.56 8.56L7 7.12L5.56 5.69L4.85 6.4L5.44 7H0V8H5.44L4.85 8.6L5.56 8.56Z" />
+            <path d="M9.41 12.41L8 11L9.41 9.59L10.12 10.3L9.53 10.89H12V5H11V9.89H9.53L10.12 9.3L9.41 9.34V12.41Z" />
           </svg>
           <span>Diff Viewer</span>
         </div>
         <div className="diff-viewer-controls">
-          <div className="diff-stats">
-            <span className="stat additions">+{stats.additions}</span>
-            <span className="stat deletions">-{stats.deletions}</span>
-          </div>
-          <select 
+          <DiffSummary stats={diffComputation.stats} />
+          <select
             className="language-selector"
-            value={language} 
-            onChange={(e) => setLanguage(e.target.value)}
+            value={language}
+            onChange={(event) => setLanguage(event.target.value)}
           >
-            <option value="javascript">JavaScript</option>
-            <option value="typescript">TypeScript</option>
-            <option value="jsx">JSX</option>
-            <option value="tsx">TSX</option>
-            <option value="css">CSS</option>
-            <option value="json">JSON</option>
-            <option value="plaintext">Plain Text</option>
+            {LANGUAGE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
           </select>
-          <div className="view-mode-toggle">
-            <button 
-              className={clsx('view-mode-btn', { active: viewMode === 'split' })}
-              onClick={() => setViewMode('split')}
-              title="Split View"
-            >
-              <svg viewBox="0 0 16 16" fill="currentColor">
-                <path d="M1 1v14h14V1H1zm1 1h5.5v12H2V2zm6.5 12V2H14v12H8.5z"/>
-              </svg>
-            </button>
-            <button 
-              className={clsx('view-mode-btn', { active: viewMode === 'unified' })}
-              onClick={() => setViewMode('unified')}
-              title="Unified View"
-            >
-              <svg viewBox="0 0 16 16" fill="currentColor">
-                <path d="M1 1v14h14V1H1zm1 1h12v12H2V2z"/>
-              </svg>
-            </button>
-          </div>
         </div>
       </div>
 
-      <div className="diff-viewer-input">
-        <div className="input-pane">
-          <div className="pane-header">
-            <span className="pane-title">Original</span>
-            <button 
-              className="clear-btn"
-              onClick={() => setLeftText('')}
-              title="Clear"
-            >
-              Clear
-            </button>
-          </div>
-          <textarea
-            className="code-input"
-            value={leftText}
-            onChange={(e) => setLeftText(e.target.value)}
-            onPaste={handlePaste(setLeftText)}
-            placeholder="Paste or type your original code here..."
-            spellCheck={false}
-          />
-        </div>
-        <div className="input-pane">
-          <div className="pane-header">
-            <span className="pane-title">Modified</span>
-            <button 
-              className="clear-btn"
-              onClick={() => setRightText('')}
-              title="Clear"
-            >
-              Clear
-            </button>
-          </div>
-          <textarea
-            className="code-input"
-            value={rightText}
-            onChange={(e) => setRightText(e.target.value)}
-            onPaste={handlePaste(setRightText)}
-            placeholder="Paste or type your modified code here..."
-            spellCheck={false}
-          />
-        </div>
-      </div>
-
-      <div className="diff-viewer-output">
-        {viewMode === 'split' ? (
-          <div className="diff-split-view">
-            <div className="diff-pane diff-pane-left">
-              <div className="diff-pane-header">
-                <span>Original</span>
-              </div>
-              <div className="diff-content">
-                {diffLines.map((line, index) => (
-                  <div
-                    key={index}
-                    className={clsx('diff-line', {
-                      'diff-line-removed': line.type === 'removed',
-                      'diff-line-empty': line.type === 'added',
-                    })}
-                  >
-                    <span className="line-number">
-                      {line.leftLineNumber || ''}
-                    </span>
-                    <pre className="line-content">
-                      {line.type !== 'added' && (
-                        <code 
-                          dangerouslySetInnerHTML={{ 
-                            __html: highlightSyntax(line.leftContent) 
-                          }} 
-                        />
-                      )}
-                    </pre>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div className="diff-pane diff-pane-right">
-              <div className="diff-pane-header">
-                <span>Modified</span>
-              </div>
-              <div className="diff-content">
-                {diffLines.map((line, index) => (
-                  <div
-                    key={index}
-                    className={clsx('diff-line', {
-                      'diff-line-added': line.type === 'added',
-                      'diff-line-empty': line.type === 'removed',
-                    })}
-                  >
-                    <span className="line-number">
-                      {line.rightLineNumber || ''}
-                    </span>
-                    <pre className="line-content">
-                      {line.type !== 'removed' && (
-                        <code 
-                          dangerouslySetInnerHTML={{ 
-                            __html: highlightSyntax(line.rightContent) 
-                          }} 
-                        />
-                      )}
-                    </pre>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="diff-unified-view">
-            <div className="diff-pane">
-              <div className="diff-pane-header">
-                <span>Changes</span>
-              </div>
-              <div className="diff-content">
-                {diffLines.map((line, index) => (
-                  <div
-                    key={index}
-                    className={clsx('diff-line', {
-                      'diff-line-added': line.type === 'added',
-                      'diff-line-removed': line.type === 'removed',
-                    })}
-                  >
-                    <span className="line-number">
-                      {line.type === 'removed' 
-                        ? line.leftLineNumber 
-                        : line.rightLineNumber || ''}
-                    </span>
-                    <span className="diff-marker">
-                      {line.type === 'added' ? '+' : line.type === 'removed' ? '-' : ' '}
-                    </span>
-                    <pre className="line-content">
-                      <code 
-                        dangerouslySetInnerHTML={{ 
-                          __html: highlightSyntax(
-                            line.type === 'removed' ? line.leftContent : line.rightContent
-                          ) 
-                        }} 
-                      />
-                    </pre>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        )}
+      <div className="diff-columns">
+        <DiffEditorPane
+          title="Original"
+          value={originalCode}
+          placeholder="Paste or type your original code here..."
+          onChange={setOriginalCode}
+          onPaste={handlePaste(setOriginalCode)}
+          onClear={() => setOriginalCode('')}
+          lines={diffComputation.original}
+          highlightSyntax={highlightSyntax}
+        />
+        <DiffEditorPane
+          title="Modified"
+          value={modifiedCode}
+          placeholder="Paste or type your modified code here..."
+          onChange={setModifiedCode}
+          onPaste={handlePaste(setModifiedCode)}
+          onClear={() => setModifiedCode('')}
+          lines={diffComputation.modified}
+          highlightSyntax={highlightSyntax}
+        />
       </div>
     </div>
+  );
+};
+
+const computeDiff = (original: string, modified: string): DiffComputation => {
+  if (!original && !modified) {
+    return {
+      original: [],
+      modified: [],
+      stats: { additions: 0, deletions: 0, modifications: 0 },
+    };
+  }
+
+  const diffParts = Diff.diffLines(original, modified);
+  const originalLines: PaneDiffLine[] = [];
+  const modifiedLines: PaneDiffLine[] = [];
+
+  let originalLineNumber = 1;
+  let modifiedLineNumber = 1;
+  let additions = 0;
+  let deletions = 0;
+  let modificationsCount = 0;
+
+  for (let index = 0; index < diffParts.length; index += 1) {
+    const part = diffParts[index];
+    const currentLines = extractLines(part.value);
+
+    if (part.removed) {
+      const nextPart = diffParts[index + 1];
+
+      if (nextPart?.added) {
+        const nextLines = extractLines(nextPart.value);
+        const pairedLength = Math.min(currentLines.length, nextLines.length);
+
+        for (let pairIndex = 0; pairIndex < pairedLength; pairIndex += 1) {
+          originalLines.push({
+            type: 'modified',
+            content: currentLines[pairIndex],
+            lineNumber: originalLineNumber++,
+          });
+          modifiedLines.push({
+            type: 'modified',
+            content: nextLines[pairIndex],
+            lineNumber: modifiedLineNumber++,
+          });
+          modificationsCount += 1;
+        }
+
+        if (currentLines.length > pairedLength) {
+          for (let leftover = pairedLength; leftover < currentLines.length; leftover += 1) {
+            originalLines.push({
+              type: 'removed',
+              content: currentLines[leftover],
+              lineNumber: originalLineNumber++,
+            });
+            deletions += 1;
+          }
+        }
+
+        if (nextLines.length > pairedLength) {
+          for (let leftover = pairedLength; leftover < nextLines.length; leftover += 1) {
+            modifiedLines.push({
+              type: 'added',
+              content: nextLines[leftover],
+              lineNumber: modifiedLineNumber++,
+            });
+            additions += 1;
+          }
+        }
+
+        index += 1;
+        continue;
+      }
+
+      for (const line of currentLines) {
+        originalLines.push({
+          type: 'removed',
+          content: line,
+          lineNumber: originalLineNumber++,
+        });
+        deletions += 1;
+      }
+      continue;
+    }
+
+    if (part.added) {
+      for (const line of currentLines) {
+        modifiedLines.push({
+          type: 'added',
+          content: line,
+          lineNumber: modifiedLineNumber++,
+        });
+        additions += 1;
+      }
+      continue;
+    }
+
+    for (const line of currentLines) {
+      originalLines.push({
+        type: 'unchanged',
+        content: line,
+        lineNumber: originalLineNumber++,
+      });
+      modifiedLines.push({
+        type: 'unchanged',
+        content: line,
+        lineNumber: modifiedLineNumber++,
+      });
+    }
+  }
+
+  return {
+    original: originalLines,
+    modified: modifiedLines,
+    stats: {
+      additions,
+      deletions,
+      modifications: modificationsCount,
+    },
+  };
+};
+
+const extractLines = (value: string): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  const splitLines = value.split('\n');
+  if (splitLines.length > 0 && splitLines[splitLines.length - 1] === '') {
+    splitLines.pop();
+  }
+  return splitLines;
+};
+
+const DiffSummary: React.FC<{ stats: DiffStats }> = ({ stats }) => {
+  return (
+    <div className="diff-stats">
+      <span className="stat additions">+{stats.additions}</span>
+      <span className="stat deletions">-{stats.deletions}</span>
+      <span className="stat modifications">±{stats.modifications}</span>
+    </div>
+  );
+};
+
+const DiffEditorPane: React.FC<DiffEditorPaneProps> = ({
+  title,
+  value,
+  placeholder,
+  onChange,
+  onPaste,
+  onClear,
+  lines,
+  highlightSyntax,
+}) => {
+  const highlightRef = useRef<HTMLDivElement | null>(null);
+
+  const handleScroll = useCallback((event: UIEvent<HTMLTextAreaElement>) => {
+    const { scrollTop, scrollLeft } = event.currentTarget;
+    if (highlightRef.current) {
+      highlightRef.current.style.transform = `translate(${-scrollLeft}px, ${-scrollTop}px)`;
+    }
+  }, []);
+
+  return (
+    <section className="diff-pane">
+      <header className="pane-header">
+        <span className="pane-title">{title}</span>
+        <button className="clear-btn" type="button" onClick={onClear}>
+          Clear
+        </button>
+      </header>
+      <div className="pane-editor">
+        <div className="code-layer" aria-hidden="true">
+          <div className="code-layer-scroll" ref={highlightRef}>
+            {lines.length > 0 ? (
+              lines.map((line) => (
+                <div
+                  key={line.lineNumber}
+                  className={clsx('code-line', {
+                    'code-line--added': line.type === 'added',
+                    'code-line--removed': line.type === 'removed',
+                    'code-line--modified': line.type === 'modified',
+                  })}
+                >
+                  <span className="code-line-number">{line.lineNumber}</span>
+                  <span
+                    className="code-line-content"
+                    dangerouslySetInnerHTML={{ __html: highlightSyntax(line.content) }}
+                  />
+                </div>
+              ))
+            ) : (
+              <div className="code-line code-line--empty">
+                <span className="code-line-number">1</span>
+                <span className="code-line-content">&nbsp;</span>
+              </div>
+            )}
+          </div>
+        </div>
+        <textarea
+          className="code-input"
+          value={value}
+          placeholder={placeholder}
+          spellCheck={false}
+          wrap="off"
+          onChange={(event) => onChange(event.target.value)}
+          onScroll={handleScroll}
+          onPaste={onPaste}
+        />
+      </div>
+    </section>
   );
 };
 

--- a/src/components/DiffViewer/index.ts
+++ b/src/components/DiffViewer/index.ts
@@ -1,2 +1,2 @@
 export { default } from './DiffViewer';
-export type { DiffLine, DiffType, DiffViewMode, DiffStats } from './types';
+export type { DiffComputation, DiffLineType, DiffStats, PaneDiffLine } from './types';

--- a/src/components/DiffViewer/types.ts
+++ b/src/components/DiffViewer/types.ts
@@ -1,16 +1,19 @@
-export type DiffType = 'added' | 'removed' | 'unchanged';
+export type DiffLineType = 'unchanged' | 'added' | 'removed' | 'modified';
 
-export type DiffViewMode = 'split' | 'unified';
-
-export interface DiffLine {
-  type: DiffType;
-  leftContent: string;
-  rightContent: string;
-  leftLineNumber: number | null;
-  rightLineNumber: number | null;
+export interface PaneDiffLine {
+  type: DiffLineType;
+  content: string;
+  lineNumber: number;
 }
 
 export interface DiffStats {
   additions: number;
   deletions: number;
+  modifications: number;
+}
+
+export interface DiffComputation {
+  original: PaneDiffLine[];
+  modified: PaneDiffLine[];
+  stats: DiffStats;
 }


### PR DESCRIPTION
## Summary
- replace the four-panel diff interface with a dual inline-editor layout that computes per-pane line states
- render syntax highlighted diff markup directly beneath each textarea so edits instantly reflect inline additions, deletions, and modifications
- refresh VS Code-inspired styling and stats display for the combined layout

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc7359e748323a32abbcf521927d8