### PR TITLE
Normalize Monaco editor whitespace characters

### DIFF
--- a/src/components/DiffViewer/DiffViewer.tsx
+++ b/src/components/DiffViewer/DiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useMemo, useState, type ReactElement } from 'react';
 import * as Diff from 'diff';
 
 // HLJS solo para auto-detección
@@ -14,6 +14,7 @@ import 'highlight.js/styles/vs2015.css';
 import './DiffViewer.css';
 import MonacoDiff from '../MonacoPane/MonacoDiffPane';
 import type { DiffSegment, DiffStats, DiffSegmentType, LanguageOption } from './types';
+import normalizeWhitespace from '../../utils/normalizeWhitespace';
 
 // registra lenguajes usados
 hljs.registerLanguage('javascript', javascript);
@@ -83,6 +84,14 @@ const DiffViewer = (): ReactElement => {
   const [originalText, setOriginalText] = useState<string>('');
   const [modifiedText, setModifiedText] = useState<string>('');
 
+  const handleOriginalChange = useCallback((next: string) => {
+    setOriginalText(normalizeWhitespace(next));
+  }, [setOriginalText]);
+
+  const handleModifiedChange = useCallback((next: string) => {
+    setModifiedText(normalizeWhitespace(next));
+  }, [setModifiedText]);
+
   const { original: originalSegments, modified: modifiedSegments } = useMemo(
     () => computeDiffSegments(originalText, modifiedText),
     [originalText, modifiedText]
@@ -149,8 +158,8 @@ const DiffViewer = (): ReactElement => {
             modified={modifiedText}
             leftLang={originalLang}
             rightLang={modifiedLang}
-            onOriginalChange={setOriginalText}
-            onModifiedChange={setModifiedText}
+            onOriginalChange={handleOriginalChange}
+            onModifiedChange={handleModifiedChange}
           />
         </div>
       </div>

--- a/src/utils/normalizeWhitespace.ts
+++ b/src/utils/normalizeWhitespace.ts
@@ -1,0 +1,9 @@
+const NBSP_REGEX = /[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/g;
+const INVISIBLE_REGEX = /[\u200B-\u200D\u2060\uFEFF]/g;
+
+const normalizeWhitespace = (value: string): string =>
+  value
+    .replace(NBSP_REGEX, ' ')
+    .replace(INVISIBLE_REGEX, ' ');
+
+export default normalizeWhitespace;


### PR DESCRIPTION
## Summary
- add a shared utility to replace Gemini-introduced whitespace with normal spaces
- sanitize Monaco models and DiffViewer state so inputs stay normalized while editing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4aa0928483238cea97d1e5ef56d1